### PR TITLE
updated with more inputs

### DIFF
--- a/src/cfn/kinesis-receiver-encrypted.yaml
+++ b/src/cfn/kinesis-receiver-encrypted.yaml
@@ -2,7 +2,8 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: >
   Sample template for deploying an Amazon Kinesis Data Stream
   with a role that another account can assume to 
-  write to the stream. 
+  write to the stream. Optionally add encryption by specifying
+  an AWS Key Management System encryption key.
 
 Parameters:
   BrightspaceAccountId:
@@ -25,6 +26,16 @@ Parameters:
     Description: >
       The number of shards that the stream uses. For greater provisioned throughput, increase the number of shards.
       See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html
+  StreamEncryptionKeyId:
+    Type: String
+    Default: ""
+    Description: >
+      The GUID for the customer-managed AWS KMS key to use for encryption.
+      This value must be exactly the Guid, in order for Brightspace to write to the shard. 
+      See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html
+
+Conditions:
+  HasEncryption: !Not [!Equals ["", !Ref StreamEncryptionKeyId]]
 
 Resources:
   KinesisStream:
@@ -32,6 +43,12 @@ Resources:
     Properties:
       RetentionPeriodHours: !Ref RetentionPeriodHours
       ShardCount: !Ref ShardCount
+      StreamEncryption: 
+        !If 
+          - HasEncryption
+          - { EncryptionType: "KMS",
+              KeyId: !Ref StreamEncryptionKeyId }
+          - !Ref "AWS::NoValue"
   IamRole:
     Type: AWS::IAM::Role
     Properties:
@@ -52,6 +69,16 @@ Resources:
               Action:
               - "kinesis:PutRecord"
               - "kinesis:PutRecords"
+        - !If
+            - HasEncryption
+            - PolicyName: encryptionPolicy
+              PolicyDocument:
+                Version: 2012-10-17
+                Statement:
+                - Effect: Allow
+                  Action: "kms:GenerateDataKey"
+                  Resource: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${StreamEncryptionKeyId}"
+            - !Ref "AWS::NoValue"
 
 Outputs:
   IamRoleArn:

--- a/src/cfn/kinesis-receiver.yaml
+++ b/src/cfn/kinesis-receiver.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
-  Sample template for deploying a kinesis data stream 
+  Sample template for deploying an Amazon Kinesis Data Stream
   with a role that another account can assume to 
   write to the stream. Optionally add encryption by specifying
   an AWS Key Management System encryption key.
@@ -11,7 +11,7 @@ Parameters:
     MinLength: 1
     Description: >
       The identifier of the account that will
-      publish messages *to* the kinesis stream
+      publish messages *to* the Amazon Kinesis Data Stream
   RetentionPeriodHours:
     Type: Number
     Default: 24
@@ -32,7 +32,7 @@ Parameters:
       This value can be a globally unique identifier, a fully specified 
       Amazon Resource Name (ARN) to either an alias or a key, or an alias 
       name prefixed by "alias/".You can also use a master key owned by 
-      Kinesis Data Streams by specifying the alias aws/kinesis.
+      Amazon Kinesis Data Streams by specifying the alias aws/kinesis.
       See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html
 
 Conditions:
@@ -74,11 +74,11 @@ Resources:
 Outputs:
   KinesisWriterRoleArn:
     Description: >
-      The ARN of the role that the lambda will assume
-      to write events to a customer kinesis stream.
+      The ARN of the Amazon IAM Role that the lambda will assume
+      to write events to a customer Amazon Kinesis Data Stream.
     Value: !GetAtt KinesisWriterRole.Arn
   EventStreamArn:
     Description: >
-      The identifier of the stream that Brightspace
+      The identifier of the Amazon Kinesis Data Stream that Brightspace
       events will be written to.
     Value: !GetAtt EventStream.Arn

--- a/src/cfn/kinesis-receiver.yaml
+++ b/src/cfn/kinesis-receiver.yaml
@@ -1,33 +1,55 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
-  This template contains the definition of a kinesis data stream along with a role that has permission to write to that stream. It takes in an AWS account Id as a parameter that defines which account will have permissions to assume this role. The outputs that this template generates are used by the serverless template to give permissions to the lambda.
-
-
-Outputs:
-  KinesisWriterRoleArn:
-    Description: >
-      The ARN of the role that the lambda will assume
-      to write events to a customer kinesis stream.
-    Value: !GetAtt KinesisWriterRole.Arn
-  EventStreamArn:
-    Description: >
-      The identifier of the stream that Brightspace
-      events will be written to.
-    Value: !GetAtt EventStream.Arn
+  Sample template for deploying a kinesis data stream 
+  with a role that another account can assume to 
+  write to the stream. Optionally add encryption by specifying
+  an AWS Key Management System encryption key.
 
 Parameters:
   BrightspaceAccountId:
     Type: String
+    MinLength: 1
     Description: >
       The identifier of the account that will
-      publish messages to the kinesis stream
+      publish messages *to* the kinesis stream
+  RetentionPeriodHours:
+    Type: Number
+    Default: 24
+    Description: >
+      The number of hours for the data records that are stored in shards to remain accessible. The default value is 24. For more information about the stream retention period, see Changing the Data Retention Period in the Amazon Kinesis Developer Guide.
+      See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html
+  ShardCount:
+    Type: Number
+    Default: 1
+    Description: >
+      The number of shards that the stream uses. For greater provisioned throughput, increase the number of shards.
+      See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html
+  StreamEncryptionKeyId:
+    Type: String
+    Default: ""
+    Description: >
+      The GUID for the customer-managed AWS KMS key to use for encryption.
+      This value can be a globally unique identifier, a fully specified 
+      Amazon Resource Name (ARN) to either an alias or a key, or an alias 
+      name prefixed by "alias/".You can also use a master key owned by 
+      Kinesis Data Streams by specifying the alias aws/kinesis.
+      See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html
+
+Conditions:
+  HasEncryption: !Not [!Equals ["", !Ref StreamEncryptionKeyId]]
+
 Resources:
   EventStream:
     Type: AWS::Kinesis::Stream
     Properties:
-      Name: EventStream
-      RetentionPeriodHours: 24
-      ShardCount: 1
+      RetentionPeriodHours: !Ref RetentionPeriodHours
+      ShardCount: !Ref ShardCount
+      StreamEncryption: 
+        !If 
+          - HasEncryption
+          - { EncryptionType: "KMS",
+              KeyId: !Ref StreamEncryptionKeyId}
+          - !Ref "AWS::NoValue"
   KinesisWriterRole:
     Type: AWS::IAM::Role
     Properties:
@@ -46,5 +68,17 @@ Resources:
           - Effect: Allow
             Resource: !GetAtt EventStream.Arn
             Action:
-            - kinesis:PutRecord
-            - kinesis:PutRecords
+            - "kinesis:PutRecord"
+            - "kinesis:PutRecords"
+
+Outputs:
+  KinesisWriterRoleArn:
+    Description: >
+      The ARN of the role that the lambda will assume
+      to write events to a customer kinesis stream.
+    Value: !GetAtt KinesisWriterRole.Arn
+  EventStreamArn:
+    Description: >
+      The identifier of the stream that Brightspace
+      events will be written to.
+    Value: !GetAtt EventStream.Arn

--- a/src/cfn/kinesis-receiver.yaml
+++ b/src/cfn/kinesis-receiver.yaml
@@ -31,10 +31,7 @@ Parameters:
     Default: ""
     Description: >
       The GUID for the customer-managed AWS KMS key to use for encryption.
-      This value can be a globally unique identifier, a fully specified 
-      Amazon Resource Name (ARN) to either an alias or a key, or an alias 
-      name prefixed by "alias/".You can also use a master key owned by 
-      Amazon Kinesis Data Streams by specifying the alias aws/kinesis.
+      This value must be exactly the Guid, in order for Brightspace to write to the shard. 
       See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html
 
 Conditions:
@@ -50,7 +47,7 @@ Resources:
         !If 
           - HasEncryption
           - { EncryptionType: "KMS",
-              KeyId: !Ref StreamEncryptionKeyId}
+              KeyId: !Ref StreamEncryptionKeyId }
           - !Ref "AWS::NoValue"
   IamRole:
     Type: AWS::IAM::Role
@@ -63,15 +60,25 @@ Resources:
             AWS: !Ref BrightspaceAccountId
           Action: "sts:AssumeRole"
       Policies:
-      - PolicyName: policy
-        PolicyDocument:
-          Version: 2012-10-17
-          Statement:
-          - Effect: Allow
-            Resource: !GetAtt KinesisStream.Arn
-            Action:
-            - "kinesis:PutRecord"
-            - "kinesis:PutRecords"
+        - PolicyName: streamWriterPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+            - Effect: Allow
+              Resource: !GetAtt KinesisStream.Arn
+              Action:
+              - "kinesis:PutRecord"
+              - "kinesis:PutRecords"
+        - !If
+            - HasEncryption
+            - PolicyName: encryptionPolicy
+              PolicyDocument:
+                Version: 2012-10-17
+                Statement:
+                - Effect: Allow
+                  Action: "kms:GenerateDataKey"
+                  Resource: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${StreamEncryptionKeyId}"
+            - !Ref "AWS::NoValue"
 
 Outputs:
   IamRoleArn:
@@ -79,8 +86,8 @@ Outputs:
       The ARN of the Amazon IAM Role that the lambda will assume
       to write events to a customer Amazon Kinesis Data Stream.
     Value: !GetAtt IamRole.Arn
-  KinesisStreamArn:
+  KinesisStreamName:
     Description: >
       The identifier of the Amazon Kinesis Data Stream that Brightspace
       events will be written to.
-    Value: !GetAtt KinesisStream.Arn
+    Value: !Ref KinesisStream

--- a/src/cfn/kinesis-receiver.yaml
+++ b/src/cfn/kinesis-receiver.yaml
@@ -8,7 +8,6 @@ Description: >
 Parameters:
   BrightspaceAccountId:
     Type: String
-    MinLength: 1
     Description: >
       The identifier of the account that will
       publish messages *to* the Amazon Kinesis Data Stream
@@ -16,7 +15,10 @@ Parameters:
     Type: Number
     Default: 24
     Description: >
-      The number of hours for the data records that are stored in shards to remain accessible. The default value is 24. For more information about the stream retention period, see Changing the Data Retention Period in the Amazon Kinesis Developer Guide.
+      The number of hours for the data records that are stored in shards to 
+      remain accessible. The default value is 24. For more information 
+      about the stream retention period, see Changing the Data Retention 
+      Period in the Amazon Kinesis Developer Guide.
       See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html
   ShardCount:
     Type: Number
@@ -39,7 +41,7 @@ Conditions:
   HasEncryption: !Not [!Equals ["", !Ref StreamEncryptionKeyId]]
 
 Resources:
-  EventStream:
+  KinesisStream:
     Type: AWS::Kinesis::Stream
     Properties:
       RetentionPeriodHours: !Ref RetentionPeriodHours
@@ -50,7 +52,7 @@ Resources:
           - { EncryptionType: "KMS",
               KeyId: !Ref StreamEncryptionKeyId}
           - !Ref "AWS::NoValue"
-  KinesisWriterRole:
+  IamRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -66,19 +68,19 @@ Resources:
           Version: 2012-10-17
           Statement:
           - Effect: Allow
-            Resource: !GetAtt EventStream.Arn
+            Resource: !GetAtt KinesisStream.Arn
             Action:
             - "kinesis:PutRecord"
             - "kinesis:PutRecords"
 
 Outputs:
-  KinesisWriterRoleArn:
+  IamRoleArn:
     Description: >
       The ARN of the Amazon IAM Role that the lambda will assume
       to write events to a customer Amazon Kinesis Data Stream.
-    Value: !GetAtt KinesisWriterRole.Arn
-  EventStreamArn:
+    Value: !GetAtt IamRole.Arn
+  KinesisStreamArn:
     Description: >
       The identifier of the Amazon Kinesis Data Stream that Brightspace
       events will be written to.
-    Value: !GetAtt EventStream.Arn
+    Value: !GetAtt KinesisStream.Arn


### PR DESCRIPTION
# Quality Plan Report:
## Introduction
This is intended to be the Quality plan for the cloudformation template that we'll deliver to Deakin via email. Regarding the other repository, I plan to remove it since it's organized in such a way that could be construed as public-facing, so it might be made public in the future.  We can talk about how a repository that is intended to be bundled and released should be structured, but for now I'm going to use this clearly demarcated test repo as a vehicle for the template review.

## Functional testing:
We deployed this shard both with and without a KMS key, and wrote to it with our Dev-EventStreaming account. Both the lambda and the ec2 instance were able to write to it. Other accounts, including the account where the Data Stream was deployed, were not.  The discussed integration test has not been created as it is out of scope for this story, but the story has been: https://rally1.rallydev.com/#/detail/userstory/311168252904
I used my tester app to run writer tests: https://git.dev.d2l/users/jwong/repos/kinesis-tester/browse
Screenshot of the encrypted kinesis stream after I run my test:
![kinesistest1](https://user-images.githubusercontent.com/13037346/59218091-630da900-8b8d-11e9-8792-b3e497b587fc.PNG)
Screenshot of the unencrypted kinesis stream after I run my test:
![kinesistest2](https://user-images.githubusercontent.com/13037346/59221067-6bb5ad80-8b94-11e9-8061-d3d7c76dc50a.PNG)
Additionally, you can add a key parameter to add encryption to an existing deployment, but passing an empty key will not remove encryption.


## DevOps:
We added configurable retentionperiods and shard counts, as well as adding an optional kms key. Something I discovered when re-deploying a cloudformation template is that if you provide an override parameter when you deploy the Kinesis data stream, if you don't provide that parameter on your next deployments, it will keep the existing parameter.  The way to remove the old parameter is to provide that parameter with an empty value.


## Documentation
Copyright: we can use text from AWS documentation, as long as we include a link. @ViktorHaag to review. 

About template ordering:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html
And the relevant text:
```Templates include several major sections. The Resources section is the only required section. Some sections in a template can be in any order. However, as you build your template, it can be helpful to use the logical order shown in the following list because values in one section might refer to values from a previous section.```

## Security:
We've provided a KMS key parameter for deakin to add their own key, if they want.  We've exposed the correct permissions for writing to the stream, kinesis:PutRecord and kinesis:PutRecords.

## Performance tests:
The shardcount property that has been exposed allows deakin to configure their event throughput.


# Task List
